### PR TITLE
Add agentmemory to Memory subsection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Lint](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/lint.yml/badge.svg)](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/lint.yml)
 [![Links](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/links.yml/badge.svg)](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/links.yml)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](../../pulls)
-![Tools](https://img.shields.io/badge/tools-131-blue.svg)
+![Tools](https://img.shields.io/badge/tools-132-blue.svg)
 ![Categories](https://img.shields.io/badge/categories-27-purple.svg)
 ![Made with](https://img.shields.io/badge/made%20with-%E2%9D%A4-red.svg)
 
@@ -327,6 +327,9 @@ What agents need to be useful in production.
 
 ### Memory
 
+- [agentmemory](https://github.com/rohitg00/agentmemory) - Persistent memory layer that captures, compresses, and replays coding-agent sessions across 15+ tools via MCP.
+  - **Strengths:** benchmarked retrieval on LongMemEval-S; broad agent coverage (Claude Code, Cursor, Cline, etc.); zero external databases.
+  - **Caveats:** young project with rapidly evolving API; pinned to older iii-engine version.
 - [Cognee](https://github.com/topoteretes/cognee) - Memory engine with knowledge graphs, ECL pipeline, and multi-hop reasoning.
   - **Strengths:** unified multi-source ingestion; agent learning across sessions; 4-method simplicity.
   - **Caveats:** hidden complexity behind simplicity; external LLM API dependency; operational maturity questions.


### PR DESCRIPTION
## Summary
- Adds [agentmemory](https://github.com/rohitg00/agentmemory) (Apache-2.0) to the Memory subsection — persistent memory layer for AI coding agents with MCP-based integration across 15+ tools (Claude Code, Cursor, Cline, Gemini CLI, etc.).
- Inclusion signals: 5.3K stars, 507 forks, 12 contributors, 100+ commits in the last 30 days, 31 releases, LongMemEval-S benchmark.
- Bumps Tools count badge 131 → 132. No new section/subsection; alphabetical placement (agentmemory sorts before Cognee, case-insensitive).

## Test plan
- [x] `npx -y markdownlint-cli2 "README.md"` — 0 errors
- [x] New URL verified via `gh api repos/rohitg00/agentmemory` (returned full repo metadata)
- [ ] CI lint workflow passes
- [ ] CI links workflow (lychee) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)