### PR TITLE
Add GitHub MCP Server to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Lint](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/lint.yml/badge.svg)](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/lint.yml)
 [![Links](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/links.yml/badge.svg)](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/links.yml)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](../../pulls)
-![Tools](https://img.shields.io/badge/tools-131-blue.svg)
+![Tools](https://img.shields.io/badge/tools-132-blue.svg)
 ![Categories](https://img.shields.io/badge/categories-27-purple.svg)
 ![Made with](https://img.shields.io/badge/made%20with-%E2%9D%A4-red.svg)
 
@@ -146,6 +146,9 @@ Add-ons that extend AI coding agents with new capabilities, knowledge, or rules.
 - [Figma MCP](https://github.com/GLips/Figma-Context-MCP) - MCP server giving agents semantic access to Figma designs for design-to-code.
   - **Strengths:** agent access to Figma data; single-shot implementation; optimized for Cursor.
   - **Caveats:** requires Figma API token; configuration overhead; Cursor-focused; context filtering trade-off.
+- [GitHub MCP Server](https://github.com/github/github-mcp-server) - GitHub's official MCP server giving agents access to repos, issues, pull requests, and Actions via the GitHub API.
+  - **Strengths:** first-party from GitHub; covers repos, issues, PRs, Actions, and code search; widely adopted (30k+ stars).
+  - **Caveats:** requires GitHub personal access token with appropriate scopes; rate-limited by token tier.
 - [microsoft/mcp](https://github.com/microsoft/mcp) - Microsoft's official MCP server implementations.
   - **Strengths:** first-party Microsoft implementations; enterprise-aware; well-tested.
   - **Caveats:** Microsoft-stack bias; some servers are early.


### PR DESCRIPTION
## What does this PR do?

Adds **GitHub MCP Server** ([github/github-mcp-server](https://github.com/github/github-mcp-server)) to the **MCP Servers** subsection. This is GitHub's first-party MCP server giving coding agents access to repos, issues, pull requests, Actions, and code search via the GitHub API — a notable gap in the current list.

Also bumps the Tools badge from 131 → 132.

## Verification

```
gh api repos/github/github-mcp-server
# stars: 30,000 | forks: 4,220 | license: MIT
# pushed_at: 2026-05-20 | archived: false
```

## Checklist

- [x] Tool is actively maintained (pushed today)
- [x] Tool is focused on AI coding agents or supporting infrastructure
- [x] Homepage and primary install path work
- [x] Description is one sentence, ≤120 chars, ends with a period (114 chars)
- [x] Entry includes nested **Strengths** and **Caveats** bullets
- [x] Entry is alphabetical within its subsection (between Figma MCP and microsoft/mcp)
- [x] Proprietary / source-available status is marked inline if applicable (MIT — no marker needed)
- [x] One tool per PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)