### PR TITLE
Add FastMCP to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Lint](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/lint.yml/badge.svg)](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/lint.yml)
 [![Links](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/links.yml/badge.svg)](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/links.yml)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](../../pulls)
-![Tools](https://img.shields.io/badge/tools-131-blue.svg)
+![Tools](https://img.shields.io/badge/tools-132-blue.svg)
 ![Categories](https://img.shields.io/badge/categories-27-purple.svg)
 ![Made with](https://img.shields.io/badge/made%20with-%E2%9D%A4-red.svg)
 
@@ -143,6 +143,9 @@ Add-ons that extend AI coding agents with new capabilities, knowledge, or rules.
 - [Excalidraw MCP](https://github.com/excalidraw/excalidraw-mcp) - Official Excalidraw MCP server for streaming hand-drawn diagram creation from agents.
   - **Strengths:** official Excalidraw team implementation; mobile-optimized streaming UI; works with Claude/ChatGPT/VS Code/Goose.
   - **Caveats:** requires MCP-compatible client; local setup needs Node.js familiarity.
+- [FastMCP](https://github.com/PrefectHQ/fastmcp) - Pythonic framework for building MCP servers and clients using decorators and type hints.
+  - **Strengths:** decorator-based, type-hinted Python API; builds both servers and clients; broad community adoption (25k+ stars).
+  - **Caveats:** Python-only; pre-1.0 breaking changes still possible.
 - [Figma MCP](https://github.com/GLips/Figma-Context-MCP) - MCP server giving agents semantic access to Figma designs for design-to-code.
   - **Strengths:** agent access to Figma data; single-shot implementation; optimized for Cursor.
   - **Caveats:** requires Figma API token; configuration overhead; Cursor-focused; context filtering trade-off.


### PR DESCRIPTION
## What does this PR do?

Adds **FastMCP** ([PrefectHQ/fastmcp](https://github.com/PrefectHQ/fastmcp)) to the **MCP Servers** subsection. FastMCP is the most widely adopted Pythonic framework for building MCP servers and clients, with a decorator/type-hint API that has become a community default.

Notes:
- The repo was transferred from `jlowin/fastmcp` → `PrefectHQ/fastmcp`; the canonical URL is used.
- Placed in **MCP Servers** rather than Official Vendor SDKs because that subsection is reserved for vendor-published SDKs (Anthropic, OpenAI, Vercel).

Also bumps the Tools badge from 131 → 132.

## Verification

```
gh api repos/jlowin/fastmcp
# full_name: PrefectHQ/fastmcp (transferred)
# stars: 25,233 | forks: 2,025 | license: Apache-2.0
# pushed_at: 2026-05-20 | archived: false
```

## Checklist

- [x] Tool is actively maintained (pushed today)
- [x] Tool is focused on AI coding agents or supporting infrastructure
- [x] Homepage and primary install path work (https://gofastmcp.com)
- [x] Description is one sentence, ≤120 chars, ends with a period (88 chars)
- [x] Entry includes nested **Strengths** and **Caveats** bullets
- [x] Entry is alphabetical within its subsection (between Excalidraw MCP and Figma MCP)
- [x] Proprietary / source-available status is marked inline if applicable (Apache-2.0 — no marker needed)
- [x] One tool per PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)