### PR TITLE
Add modelcontextprotocol/inspector to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Lint](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/lint.yml/badge.svg)](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/lint.yml)
 [![Links](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/links.yml/badge.svg)](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/links.yml)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](../../pulls)
-![Tools](https://img.shields.io/badge/tools-131-blue.svg)
+![Tools](https://img.shields.io/badge/tools-132-blue.svg)
 ![Categories](https://img.shields.io/badge/categories-27-purple.svg)
 ![Made with](https://img.shields.io/badge/made%20with-%E2%9D%A4-red.svg)
 
@@ -149,6 +149,9 @@ Add-ons that extend AI coding agents with new capabilities, knowledge, or rules.
 - [microsoft/mcp](https://github.com/microsoft/mcp) - Microsoft's official MCP server implementations.
   - **Strengths:** first-party Microsoft implementations; enterprise-aware; well-tested.
   - **Caveats:** Microsoft-stack bias; some servers are early.
+- [modelcontextprotocol/inspector](https://github.com/modelcontextprotocol/inspector) - Official visual testing and debugging tool for MCP servers from the protocol working group.
+  - **Strengths:** canonical MCP-server dev/test harness; interactive tool/resource exploration; first-party MCP working-group project.
+  - **Caveats:** Node.js-based local CLI; intended for development, not production monitoring.
 - [modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers) - Official MCP reference servers for filesystem, Git, GitHub, memory, and more.
   - **Strengths:** canonical reference; minimal dependencies; copy-pasteable for most agents.
   - **Caveats:** reference-quality, not production-hardened; security trade-offs are user responsibility.


### PR DESCRIPTION
## What does this PR do?

Adds **modelcontextprotocol/inspector** ([modelcontextprotocol/inspector](https://github.com/modelcontextprotocol/inspector)) to the **MCP Servers** subsection. This is the official MCP-protocol working-group visual testing tool — the canonical local dev harness for building or debugging an MCP server.

Naming follows the existing `modelcontextprotocol/servers` entry convention (org/repo as display name).

Also bumps the Tools badge from 131 → 132.

## Verification

```
gh api repos/modelcontextprotocol/inspector
# stars: 9,819 | forks: 1,315
# license: mid-transition MIT -> Apache-2.0 (open source either way)
# pushed_at: 2026-05-20 | archived: false
```

## Checklist

- [x] Tool is actively maintained (pushed today)
- [x] Tool is focused on AI coding agents or supporting infrastructure
- [x] Homepage and primary install path work (https://modelcontextprotocol.io)
- [x] Description is one sentence, ≤120 chars, ends with a period (91 chars)
- [x] Entry includes nested **Strengths** and **Caveats** bullets
- [x] Entry is alphabetical within its subsection (between microsoft/mcp and modelcontextprotocol/servers)
- [x] Proprietary / source-available status is marked inline if applicable (OSS — no marker needed)
- [x] One tool per PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)