### PR TITLE
Add MarkItDown to Codebase Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Lint](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/lint.yml/badge.svg)](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/lint.yml)
 [![Links](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/links.yml/badge.svg)](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/links.yml)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](../../pulls)
-![Tools](https://img.shields.io/badge/tools-131-blue.svg)
+![Tools](https://img.shields.io/badge/tools-132-blue.svg)
 ![Categories](https://img.shields.io/badge/categories-27-purple.svg)
 ![Made with](https://img.shields.io/badge/made%20with-%E2%9D%A4-red.svg)
 
@@ -384,6 +384,9 @@ What agents need to be useful in production.
 - [GitNexus](https://github.com/abhigyanpatwari/GitNexus) - Client-side knowledge-graph engine for repos with zero-server, in-browser indexing.
   - **Strengths:** precomputed knowledge graphs enable smaller models; 14+ languages; local-first privacy.
   - **Caveats:** web UI capped at 5000 files; incomplete language features; commercial lock-in for advanced features.
+- [MarkItDown](https://github.com/microsoft/markitdown) - CLI and Python library that converts PDFs, Office docs, images, and audio into LLM-ready Markdown.
+  - **Strengths:** broad format coverage (PDF, Office, images, audio); Microsoft-maintained; widely adopted ingest tool.
+  - **Caveats:** general-purpose ingestion (not code-specific); audio transcription needs external API like Whisper.
 - [Repomix](https://github.com/yamadashy/repomix) - AI-friendly codebase packing with tree-sitter compression for big token reductions.
   - **Strengths:** AI-optimized formatting; 70% compression via tree-sitter; security scanning; flexible deployment.
   - **Caveats:** compression feature experimental; configuration complexity; remote config untrusted.


### PR DESCRIPTION
## What does this PR do?

Adds **MarkItDown** ([microsoft/markitdown](https://github.com/microsoft/markitdown)) to the **Codebase Context** subsection. It's Microsoft's Python library + CLI that converts PDFs, Office documents, images, and audio into LLM-ready Markdown — a common pre-step in agent ingest pipelines.

Section choice note: MarkItDown is broader than just code (any document format), but Codebase Context is the closest existing subsection — neighboring entries like Context7 (library docs) and context-hub (doc structuring) already broaden beyond strict code. Happy to relocate if a "Document Ingestion" subsection is preferred.

Also bumps the Tools badge from 131 → 132.

## Verification

```
gh api repos/microsoft/markitdown
# stars: 123,995 | forks: 8,410 | license: MIT
# pushed_at: 2026-04-20 | archived: false
```

## Checklist

- [x] Tool is actively maintained (pushed 2026-04-20)
- [x] Tool is focused on AI coding agents or supporting infrastructure
- [x] Homepage and primary install path work
- [x] Description is one sentence, ≤120 chars, ends with a period (98 chars)
- [x] Entry includes nested **Strengths** and **Caveats** bullets
- [x] Entry is alphabetical within its subsection (between GitNexus and Repomix)
- [x] Proprietary / source-available status is marked inline if applicable (MIT — no marker needed)
- [x] One tool per PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)