### PR TITLE
Add Stagehand to Sandboxing & Execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Lint](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/lint.yml/badge.svg)](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/lint.yml)
 [![Links](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/links.yml/badge.svg)](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/links.yml)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](../../pulls)
-![Tools](https://img.shields.io/badge/tools-131-blue.svg)
+![Tools](https://img.shields.io/badge/tools-132-blue.svg)
 ![Categories](https://img.shields.io/badge/categories-27-purple.svg)
 ![Made with](https://img.shields.io/badge/made%20with-%E2%9D%A4-red.svg)
 
@@ -408,6 +408,9 @@ What agents need to be useful in production.
 - [Riza](https://riza.io) - Secure sandboxing runtime for AI-generated code (proprietary).
   - **Strengths:** <10ms execution startup; billions of monthly executions; isolated execution; REST API.
   - **Caveats:** Python/TypeScript/Go only; self-hosting requires Kubernetes; pricing/limits unclear.
+- [Stagehand](https://github.com/browserbase/stagehand) - TypeScript and Python SDK for browser agents using natural-language act/extract/observe primitives.
+  - **Strengths:** natural-language browser primitives (act, extract, observe); TypeScript and Python SDKs; widely adopted browser-agent reference.
+  - **Caveats:** requires a Chromium-compatible browser environment; advanced features integrate with Browserbase's hosted cloud.
 - [Vercel Sandbox](https://vercel.com/docs/vercel-sandbox) - Lightweight sandbox execution integrated with Vercel infrastructure (proprietary).
   - **Strengths:** millisecond startup; Node24 / Python 3.13 runtimes; snapshotting; persistent beta support.
   - **Caveats:** Amazon Linux 2023 only; documentation thin; Firecracker VM constraints.


### PR DESCRIPTION
## What does this PR do?

Adds **Stagehand** ([browserbase/stagehand](https://github.com/browserbase/stagehand)) to the **Sandboxing & Execution** subsection. Stagehand is the de-facto TypeScript/Python SDK for browser agents — its `act`/`extract`/`observe` primitives have become a community-reference pattern for letting agents drive a browser.

Section choice note: Stagehand is a browser-execution environment (vs. the code-execution sandboxes that dominate this section). It's a stretch but defensible — both are "execution environments agents drive at runtime" — and the taxonomy is stable per CLAUDE.md. Reviewers can relocate if a future "Browser/Web Agents" subsection is added.

Also bumps the Tools badge from 131 → 132.

## Verification

```
gh api repos/browserbase/stagehand
# stars: 22,734 | forks: 1,527 | license: MIT
# pushed_at: 2026-05-19 | archived: false
```

## Checklist

- [x] Tool is actively maintained (pushed yesterday)
- [x] Tool is focused on AI coding agents or supporting infrastructure
- [x] Homepage and primary install path work
- [x] Description is one sentence, ≤120 chars, ends with a period (99 chars)
- [x] Entry includes nested **Strengths** and **Caveats** bullets
- [x] Entry is alphabetical within its subsection (between Riza and Vercel Sandbox)
- [x] Proprietary / source-available status is marked inline if applicable (MIT — no marker needed)
- [x] One tool per PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)