### PR TITLE
Add OneQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Add-ons that extend AI coding agents with new capabilities, knowledge, or rules.
   - **Strengths:** opinionated commands (`/grill-me`, `/write-a-prd`, `/tdd`, `/triage-issue`, `/git-guardrails`); failure-mode focus across planning/testing/safety; readable shell-based skills.
   - **Caveats:** small skill set; reflects one engineer's workflow; no built-in orchestration.
 - [OneQuery CLI](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - CLI skill for safe, auditable agent queries through OneQuery-managed data access.
-  - **Strengths:** agent-safe query validation; centralized credentials; audit trail.
+  - **Strengths:** agent-safe validation; audit trail.
   - **Caveats:** requires OneQuery setup and CLI authentication.
 - [superpowers](https://github.com/obra/superpowers) - Agentic skills framework and methodology for Claude Code, Cursor, Codex, and Gemini CLI.
   - **Strengths:** TDD/RED-GREEN-REFACTOR built in; brainstorming + planning before code; Git-worktree mgmt for parallel work.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Lint](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/lint.yml/badge.svg)](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/lint.yml)
 [![Links](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/links.yml/badge.svg)](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/links.yml)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](../../pulls)
-![Tools](https://img.shields.io/badge/tools-133-blue.svg)
+![Tools](https://img.shields.io/badge/tools-134-blue.svg)
 ![Categories](https://img.shields.io/badge/categories-27-purple.svg)
 ![Made with](https://img.shields.io/badge/made%20with-%E2%9D%A4-red.svg)
 
@@ -110,6 +110,9 @@ Add-ons that extend AI coding agents with new capabilities, knowledge, or rules.
 - [Matt Pocock's Skills](https://github.com/mattpocock/skills) - Personal Claude Code skill pack from Matt Pocock, drawn straight from his `.claude` directory.
   - **Strengths:** opinionated commands (`/grill-me`, `/write-a-prd`, `/tdd`, `/triage-issue`, `/git-guardrails`); failure-mode focus across planning/testing/safety; readable shell-based skills.
   - **Caveats:** small skill set; reflects one engineer's workflow; no built-in orchestration.
+- [OneQuery CLI](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - Agent skill for bounded, auditable read-only queries through OneQuery-managed data access.
+  - **Strengths:** centralized credentials; read-only validation; query limits and audit logs.
+  - **Caveats:** requires OneQuery setup and CLI authentication.
 - [superpowers](https://github.com/obra/superpowers) - Agentic skills framework and methodology for Claude Code, Cursor, Codex, and Gemini CLI.
   - **Strengths:** TDD/RED-GREEN-REFACTOR built in; brainstorming + planning before code; Git-worktree mgmt for parallel work.
   - **Caveats:** philosophy-heavy; best results need cultural adoption.

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ Add-ons that extend AI coding agents with new capabilities, knowledge, or rules.
 - [Matt Pocock's Skills](https://github.com/mattpocock/skills) - Personal Claude Code skill pack from Matt Pocock, drawn straight from his `.claude` directory.
   - **Strengths:** opinionated commands (`/grill-me`, `/write-a-prd`, `/tdd`, `/triage-issue`, `/git-guardrails`); failure-mode focus across planning/testing/safety; readable shell-based skills.
   - **Caveats:** small skill set; reflects one engineer's workflow; no built-in orchestration.
-- [OneQuery CLI](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - CLI skill for safe, auditable agent queries through OneQuery-managed data access.
-  - **Strengths:** agent-safe validation; audit trail.
+- [OneQuery CLI](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - CLI skill for safe, auditable queries for agents through OneQuery-managed data access.
+  - **Strengths:** query validation for agents; audit trail.
   - **Caveats:** requires OneQuery setup and CLI authentication.
 - [superpowers](https://github.com/obra/superpowers) - Agentic skills framework and methodology for Claude Code, Cursor, Codex, and Gemini CLI.
   - **Strengths:** TDD/RED-GREEN-REFACTOR built in; brainstorming + planning before code; Git-worktree mgmt for parallel work.

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ Add-ons that extend AI coding agents with new capabilities, knowledge, or rules.
 - [Matt Pocock's Skills](https://github.com/mattpocock/skills) - Personal Claude Code skill pack from Matt Pocock, drawn straight from his `.claude` directory.
   - **Strengths:** opinionated commands (`/grill-me`, `/write-a-prd`, `/tdd`, `/triage-issue`, `/git-guardrails`); failure-mode focus across planning/testing/safety; readable shell-based skills.
   - **Caveats:** small skill set; reflects one engineer's workflow; no built-in orchestration.
-- [OneQuery CLI](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - Agent skill for bounded, auditable read-only queries through OneQuery-managed data access.
-  - **Strengths:** centralized credentials; read-only validation; query limits and audit logs.
+- [OneQuery CLI](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - CLI skill for safe, auditable agent queries through OneQuery-managed data access.
+  - **Strengths:** agent-safe query validation; centralized credentials; audit trail.
   - **Caveats:** requires OneQuery setup and CLI authentication.
 - [superpowers](https://github.com/obra/superpowers) - Agentic skills framework and methodology for Claude Code, Cursor, Codex, and Gemini CLI.
   - **Strengths:** TDD/RED-GREEN-REFACTOR built in; brainstorming + planning before code; Git-worktree mgmt for parallel work.


### PR DESCRIPTION
## What does this PR do?

Adds OneQuery CLI to Claude Code Skills & Plugins.

OneQuery CLI is supporting infrastructure for safe, auditable queries for agents through approved data sources.

## Checklist

- [x] Tool is actively maintained
- [x] Tool is focused on AI coding agents or supporting infrastructure
- [x] Homepage and primary install/documentation link are included
- [x] Entry has a short, neutral description
- [x] Link works and no duplicate OneQuery entry was found before submission

## Disclosure

I am affiliated with Wordbricks/OneQuery.