### PR TITLE
feat: add TWZRD Agent Intel — trust scoring MCP server for agents with x402 micropayments

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ Add-ons that extend AI coding agents with new capabilities, knowledge, or rules.
 - [Supabase MCP](https://github.com/supabase-community/supabase-mcp) - Connect Supabase databases to Claude Code, Cursor, and other LLMs.
   - **Strengths:** standardizes LLM↔Supabase interaction; comprehensive tooling; configurable security.
   - **Caveats:** pre-1.0 (breaking changes likely); limited self-hosted features; prompt injection possible.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring and identity verification MCP server for AI agents operating with x402 micropayments on Solana.
+  - **Strengths:** free MCP tools (`score_agent`, `preflight_check`); streamable-HTTP transport; no API key required for trust scoring.
+  - **Caveats:** Solana-native identity model; `get_trust_receipt` tool requires x402 micropayment.
 
 ### Curated Awesome Lists
 


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **MCP Servers** section.

TWZRD Agent Intel is a Solana-native trust scoring and identity verification MCP server for AI coding agents that operate with x402 micropayments. It lets an agent verify the identity and reputation of another wallet before proceeding with paid tool calls.

**MCP Tools:**
- `score_agent(wallet)` — trust score (0–1) for any Solana wallet, free
- `preflight_check(wallet)` — full identity preflight before paid access, free
- `get_trust_receipt(wallet)` — signed trust receipt (x402 micropayment, ~$0.001)

**Quick config:**
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

Fits in the MCP Servers section alongside other production infrastructure servers. Particularly relevant for agents using paid MCP tools where wallet-based identity verification is needed.