### PR TITLE
Add ax observability tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,9 @@ What agents need to be useful in production.
 
 ### Observability
 
+- [ax](https://github.com/Necmttn/ax) - Local-first telemetry and memory graph for AI coding agents across Claude Code, Codex, OpenCode, Cursor, and Pi.
+  - **Strengths:** normalizes sessions, costs, tool calls, skills, OTLP events, and git-linked recall into a local SurrealDB graph; includes CLI, dashboard, and MCP access.
+  - **Caveats:** requires local ax and SurrealDB setup; focused on coding-agent harness telemetry rather than general LLM app tracing.
 - [Helicone](https://github.com/Helicone/helicone) - Open-source LLM observability platform for tracing and monitoring.
   - **Strengths:** 100+ models via single API key; one-line integration; comprehensive observability; self-hosting option.
   - **Caveats:** documentation timeliness issues; manual deployment not recommended; provider gaps possible.


### PR DESCRIPTION
## What does this PR do?

Adds ax to Supporting Infrastructure > Observability.

## Checklist

- [x] Tool is actively maintained
- [x] Tool is focused on AI coding agents or supporting infrastructure
- [x] Homepage and primary install path work
- [x] Description is one sentence, <=120 chars, ends with a period
- [x] Entry includes nested **Strengths** and **Caveats** bullets
- [x] Entry is alphabetical within its subsection
- [x] Proprietary / source-available status is marked inline if applicable
- [x] One tool per PR

## Validation

- `npx -y markdownlint-cli2 README.md`
- `git diff --check`
- Added GitHub link returns HTTP 200
- Install URL `https://ax.necmttn.com/install` returns HTTP 200
- `npx -y markdown-link-check -q README.md` reports existing unrelated failures for `../../pulls`, `../../issues`, and the Reddit link; the added ax link passes.

---

_Generated with [ax](https://github.com/Necmttn/ax)._