### PR TITLE
Add ralph-harness workflow entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,11 +207,11 @@ Add-ons that extend AI coding agents with new capabilities, knowledge, or rules.
   - **Strengths:** collected `DESIGN.md` exemplars; promotes design-first agent workflows; growing community.
   - **Caveats:** convention not yet standard; usefulness depends on agent's spec-reading capabilities.
 - [BMAD-METHOD](https://github.com/bmad-code-org/BMAD-METHOD) - Open-source agentic agile framework with guided workflows from ideation to autonomous implementation.
+  - **Strengths:** fully free, open-source; expert-collaborator personas; scale-domain-adaptive planning.
+  - **Caveats:** requires CLI invocation (`npx bmad-method@next install`); newer methodology with evolving personas.
 - [ralph-harness](https://github.com/rxdt/py_ralph_frame) - Minimal repo-local guarded loop for Claude Code, Codex CLI, and Gemini CLI.
   - **Strengths:** specs as source of truth; fresh-context iterations; git hooks and CI gates; hard iteration/time caps; simple local scaffold instead of a hosted orchestrator.
   - **Caveats:** new project; PyPI Trusted Publishing is pending, so the current trial path installs from GitHub.
-  - **Strengths:** fully free, open-source; expert-collaborator personas; scale-domain-adaptive planning.
-  - **Caveats:** requires CLI invocation (`npx bmad-method@next install`); newer methodology with evolving personas.
 - [claude-code-best-practice](https://github.com/shanraisshan/claude-code-best-practice) - Distilled best-practice patterns and conventions for Claude Code teams.
   - **Strengths:** concise reference of community-tested patterns; quick-start for new teams; living doc.
   - **Caveats:** opinionated; may not match every workflow; small maintainer pool.

--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ Add-ons that extend AI coding agents with new capabilities, knowledge, or rules.
   - **Strengths:** collected `DESIGN.md` exemplars; promotes design-first agent workflows; growing community.
   - **Caveats:** convention not yet standard; usefulness depends on agent's spec-reading capabilities.
 - [BMAD-METHOD](https://github.com/bmad-code-org/BMAD-METHOD) - Open-source agentic agile framework with guided workflows from ideation to autonomous implementation.
+- [ralph-harness](https://github.com/rxdt/py_ralph_frame) - Minimal repo-local guarded loop for Claude Code, Codex CLI, and Gemini CLI.
+  - **Strengths:** specs as source of truth; fresh-context iterations; git hooks and CI gates; hard iteration/time caps; simple local scaffold instead of a hosted orchestrator.
+  - **Caveats:** new project; PyPI Trusted Publishing is pending, so the current trial path installs from GitHub.
   - **Strengths:** fully free, open-source; expert-collaborator personas; scale-domain-adaptive planning.
   - **Caveats:** requires CLI invocation (`npx bmad-method@next install`); newer methodology with evolving personas.
 - [claude-code-best-practice](https://github.com/shanraisshan/claude-code-best-practice) - Distilled best-practice patterns and conventions for Claude Code teams.


### PR DESCRIPTION
Adds `ralph-harness` under **Methodologies & Spec-Driven Workflows**.

Why it fits:
- It is a concrete runnable scaffold for a guarded coding-agent loop.
- Supports Claude Code, Codex CLI, and Gemini CLI.
- Uses specs, fresh-context iterations, git hooks, CI gates, and hard iteration/time caps.

Trial command:

```sh
uvx --from git+https://github.com/rxdt/py_ralph_frame ralph-harness demo
```

Related candidate issue: #22