### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Lint](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/lint.yml/badge.svg)](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/lint.yml)
 [![Links](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/links.yml/badge.svg)](https://github.com/namphuongtran/awesome-ai-coding-agent-tools/actions/workflows/links.yml)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](../../pulls)
-![Tools](https://img.shields.io/badge/tools-133-blue.svg)
+![Tools](https://img.shields.io/badge/tools-134-blue.svg)
 ![Categories](https://img.shields.io/badge/categories-27-purple.svg)
 ![Made with](https://img.shields.io/badge/made%20with-%E2%9D%A4-red.svg)
 
@@ -348,6 +348,9 @@ What agents need to be useful in production.
 - [Mem0](https://github.com/mem0ai/mem0) - Universal memory layer with semantic, BM25, and entity-linked retrieval.
   - **Strengths:** multi-level memory architecture; intuitive cross-platform SDKs; 91%+ benchmark improvements.
   - **Caveats:** LLM provider dependency; embedding-model requirements; self-hosted operational overhead.
+- [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) - Local-first Rust CLI memory lifecycle layer for AI coding agents.
+  - **Strengths:** framework-agnostic CLI; SQLite/FTS recall; forgetting, audit, and consolidation workflows.
+  - **Caveats:** young project; small early community; macOS ARM64 binary is the primary release artifact today.
 - [Zep](https://github.com/getzep/zep) - Long-term memory management for agents with semantic search and summarization.
   - **Strengths:** sub-200ms context assembly; temporal knowledge graphs; multi-language SDKs; SOC2/HIPAA.
   - **Caveats:** WIP status; Community Edition deprecated; cloud-vendor dependency; documentation gaps.


### PR DESCRIPTION
## What does this PR do?

Adds Tree Ring Memory to Supporting Infrastructure > Memory.

Tree Ring Memory is a framework-agnostic, local-first Rust CLI memory lifecycle layer for AI coding agents, with SQLite/FTS recall, forgetting, audit, consolidation, DOX/Revolve adapters, and TUI workflows.

## Checklist

- [x] Tool is actively maintained
- [x] Tool is focused on AI coding agents or supporting infrastructure
- [x] Homepage and primary install path work
- [x] Description is one sentence, ≤120 chars, ends with a period
- [x] Entry includes nested **Strengths** and **Caveats** bullets
- [x] Entry is alphabetical within its subsection
- [x] Proprietary / source-available status is marked inline if applicable
- [x] One tool per PR

## Evidence

- Repo: https://github.com/TerminallyLazy/Tree-Ring-Memory
- Recent activity verified via GitHub API: pushed 2026-07-07, MIT license, not archived.
- Local validation: markdownlint-cli2 v0.23.0 (markdownlint v0.41.0)
Finding: README.md
Linting: 1 file(s)
Summary: 0 error(s) passed with 0 errors.