### PR TITLE
Add SandBase CLI to MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ Add-ons that extend AI coding agents with new capabilities, knowledge, or rules.
 - [Playwright MCP](https://github.com/microsoft/playwright-mcp) - Microsoft's MCP server for browser automation and end-to-end testing.
   - **Strengths:** accessibility tree (no vision models); fast and lightweight; avoids screenshot ambiguity.
   - **Caveats:** not a security boundary; headless Chromium only; profile conflicts under concurrency.
+- [SandBase CLI](https://github.com/sandbaseai/cli) - Agent-first CLI and MCP bridge connecting coding agents to 2,000+ hosted models and APIs.
+  - **Strengths:** one-command setup for 17+ clients; six-tool discover/inspect/run surface; OAuth device flow; Apache-2.0.
+  - **Caveats:** requires a SandBase account and hosted service; model and API calls may consume credits; Node.js 20+ required.
 - [Serena](https://github.com/oraios/serena) - MCP toolkit giving agents IDE-like semantic retrieval and editing via Language Server Protocol.
   - **Strengths:** LSP-powered semantic ops (rename/references/navigation); multi-language; widely adopted (24k+ stars); free OSS.
   - **Caveats:** requires per-language LSP servers installed; setup complexity varies by language.


### PR DESCRIPTION
## What does this PR do?

Adds SandBase CLI to the MCP Servers subsection. SandBase is an Apache-2.0 CLI and MCP bridge that connects coding agents to a hosted catalog of 2,000+ models and APIs through a compact six-tool interface.

## Why it fits

- Directly extends AI coding agents through MCP
- Supports 17+ clients, including Claude Code, Codex, Cursor, Gemini CLI, OpenCode, and Windsurf
- Shows visible usage: 1,776 npm downloads in the latest completed monthly reporting window and 109 in the latest completed week
- Includes balanced strengths and caveats, including hosted-service, account, credit, and Node.js requirements

## Checklist

- [x] Tool is actively maintained
- [x] Tool is focused on AI coding agents or supporting infrastructure
- [x] Homepage and primary install path work
- [x] Description is one sentence, ≤120 chars, ends with a period
- [x] Entry includes nested **Strengths** and **Caveats** bullets
- [x] Entry is alphabetical within its subsection
- [x] Proprietary / source-available status is marked inline if applicable
- [x] One tool per PR

## Validation

- `npx -y markdownlint-cli2 README.md` — 0 issues
- `git diff --check` — passed

Disclosure: I am affiliated with SandBase. AI assistance was used to prepare this contribution.